### PR TITLE
Update Algolia Docsearch URL

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,7 @@ Our laravel-site-search package is not tied to Eloquent models. Like Google, it 
 
 ## How does this package differ from Algolia Docsearch?
 
-[Algolia Docsearch](https://laravel.com/docs/8.x/scout) is an awesome solution for adding search capabilities to open-source documentation. 
+[Algolia Docsearch](https://docsearch.algolia.com/) is an awesome solution for adding search capabilities to open-source documentation. 
 
 Our laravel-site-search package may be used to index non-open-source stuff as well. Where Docsearch makes basic assumptions on how the content is structured, our package tries to make a best effort to index all kinds of content.
 


### PR DESCRIPTION
The original URL for Algolia Docsearch was to the Laravel Scout docs. This PR points it to the correct page.