### PR TITLE
Fix event constructors

### DIFF
--- a/src/Events/FailedToCrawlUrlEvent.php
+++ b/src/Events/FailedToCrawlUrlEvent.php
@@ -10,7 +10,7 @@ class FailedToCrawlUrlEvent
     public function __construct(
         public UriInterface $url,
         public RequestException $requestException,
-        public?UriInterface $foundOnUrl = null
+        public ?UriInterface $foundOnUrl = null
     ) {
     }
 }

--- a/src/Events/IndexedUrlEvent.php
+++ b/src/Events/IndexedUrlEvent.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\UriInterface;
 class IndexedUrlEvent
 {
     public function __construct(
-        UriInterface $url,
-        ResponseInterface $response,
-        ?UriInterface $foundOnUrl = null
+        public UriInterface $url,
+        public ResponseInterface $response,
+        public ?UriInterface $foundOnUrl = null
     ) {
     }
 }


### PR DESCRIPTION
- The `IndexedUrlEvent` was missing the visibility keywords for constructor property promotion.
- Added a missing space between the visibility and the property type.