### PR TITLE
Fix highlightedSnippet looking in wrong place

### DIFF
--- a/src/SearchResults/Hit.php
+++ b/src/SearchResults/Hit.php
@@ -44,10 +44,15 @@ class Hit
     {
         $propertyName = $this->getSnippetProperty();
 
-        $propertyName = ucfirst($propertyName);
-        $propertyName = 'highlighted' . $propertyName;
+        if (!is_array($this->_formatted)){
+            return null;
+        }
 
-        return $this->$propertyName;
+        if (!array_key_exists($propertyName, $this->_formatted)){
+            return null;
+        }
+
+        return $this->_formatted[$propertyName];
     }
 
     protected function getSnippetProperty(): string


### PR DESCRIPTION
As others have noticed in a previous issue / discussion (https://github.com/spatie/laravel-site-search/issues/14 and https://github.com/spatie/laravel-site-search/discussions/16 respectively) that `highlightedSnippet()` was returning null but `snippet()` was returning content.

Looking at both the Meilisearch docs (https://docs.meilisearch.com/reference/features/search_parameters.html#attributes-to-highlight) and the properties of `Spatie\SiteSearch\SearchResults\Hit`, the highlighted properties will actually be within an array called `_formatted`, whereas this package was previously looking for `highlightedDescription`, `highlightedEntry` or `highlightedH1` (assuming the default MeiliSearchDriver was in use).

The function itself will still either return `null` (if either `_formatted` isn't an array (which would only be the case if the `attributesToHighlight` search parameter is empty from what I can see) or the property name cannot be found in `_formatted`) or the string from the `_formatted` array.

Thanks