### PR TITLE
Introduce possibilty to modify the indexed URLs

### DIFF
--- a/docs/advanced-usage/using-a-custom-indexer.md
+++ b/docs/advanced-usage/using-a-custom-indexer.md
@@ -15,6 +15,7 @@ If the results yielded by `DefaultIndexer` are not good enough for your content,
 namespace Spatie\SiteSearch\Indexers;
 
 use Carbon\CarbonInterface;
+use Psr\Http\Message\UriInterface;
 
 interface Indexer
 {
@@ -51,6 +52,11 @@ interface Indexer
      * More info: https://spatie.be/docs/laravel-site-search/v1/advanced-usage/indexing-extra-properties
      */
     public function extra(): array;
+    
+    /*
+     * This function should return the url of the page.
+     */
+     public function url(): UriInterface;
 }
 ```
 
@@ -82,6 +88,42 @@ class Indexer extends DefaultIndexer
             '',
             parent::pageTitle()
         );
+    }
+}
+```
+
+Here's an example of a custom indexer to strip away the query parameters from the url.
+
+```php
+
+namespace App\Services\Search;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\SiteSearch\Indexers\DefaultIndexer;
+
+class Indexer extends DefaultIndexer
+{
+    public function url(): UriInterface
+    {
+        return $this->url->withQuery('');
+    }
+}
+```
+
+Here's an example of a custom indexer to use the canonical url (if applicable) as the url.
+
+```php
+
+namespace App\Services\Search;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\SiteSearch\Indexers\DefaultIndexer;
+
+class Indexer extends DefaultIndexer
+{
+    public function url(): UriInterface
+    {
+        return attempt(fn () => $this->domCrawler->filter('link[rel="canonical"]')->first()->attr('href')) ?? parent::url();
     }
 }
 ```

--- a/docs/advanced-usage/using-a-custom-indexer.md
+++ b/docs/advanced-usage/using-a-custom-indexer.md
@@ -116,6 +116,7 @@ Here's an example of a custom indexer to use the canonical url (if applicable) a
 
 namespace App\Services\Search;
 
+use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
 use Spatie\SiteSearch\Indexers\DefaultIndexer;
 
@@ -123,7 +124,13 @@ class Indexer extends DefaultIndexer
 {
     public function url(): UriInterface
     {
-        return attempt(fn () => $this->domCrawler->filter('link[rel="canonical"]')->first()->attr('href')) ?? parent::url();
+        $canonical = attempt(fn () => $this->domCrawler->filter('link[rel="canonical"]')->first()->attr('href'));
+        
+        if (! $canonical) {
+            return parent::url();
+        }
+        
+        return new Uri($canonical);
     }
 }
 ```

--- a/src/Crawler/SearchProfileCrawlObserver.php
+++ b/src/Crawler/SearchProfileCrawlObserver.php
@@ -41,6 +41,7 @@ class SearchProfileCrawlObserver extends CrawlObserver
         $dateModified = $indexer->dateModified();
         $description = $indexer->description();
         $extra = $indexer->extra();
+        $url = $indexer->url();
 
         $documents = collect($indexer->entries())
             ->map(function (string $entry) use ($extra, $dateModified, $url, $h1, $description, $pageTitle) {

--- a/src/Indexers/DefaultIndexer.php
+++ b/src/Indexers/DefaultIndexer.php
@@ -3,6 +3,7 @@
 namespace Spatie\SiteSearch\Indexers;
 
 use Carbon\CarbonInterface;
+use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\DomCrawler\Crawler;
@@ -106,5 +107,10 @@ class DefaultIndexer implements Indexer
     public function dateModified(): ?CarbonInterface
     {
         return now();
+    }
+
+    public function url(): UriInterface
+    {
+        return $this->url;
     }
 }

--- a/src/Indexers/Indexer.php
+++ b/src/Indexers/Indexer.php
@@ -3,6 +3,7 @@
 namespace Spatie\SiteSearch\Indexers;
 
 use Carbon\CarbonInterface;
+use Psr\Http\Message\UriInterface;
 
 interface Indexer
 {
@@ -39,4 +40,9 @@ interface Indexer
      * More info: https://spatie.be/docs/laravel-site-search/v1/advanced-usage/indexing-extra-properties
      */
     public function extra(): array;
+
+    /*
+     * This function should return the url of the page.
+     */
+    public function url(): UriInterface;
 }

--- a/tests/TestSupport/Server/public/routeFiles/modifyUrl.php
+++ b/tests/TestSupport/Server/public/routeFiles/modifyUrl.php
@@ -1,0 +1,13 @@
+<?php
+
+$router->get(
+    '/',
+    fn () =>
+<<<HTML
+        Here is the homepage
+        <a href="/page?with=query">Next page</a>
+    HTML
+);
+$router->get('/page', fn () => response(
+    'Page with query',
+));

--- a/tests/TestSupport/TestClasses/Indexers/IndexerWithModifiedUrl.php
+++ b/tests/TestSupport/TestClasses/Indexers/IndexerWithModifiedUrl.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\TestSupport\TestClasses\Indexers;
+
+use Psr\Http\Message\UriInterface;
+use Spatie\SiteSearch\Indexers\DefaultIndexer;
+
+class IndexerWithModifiedUrl extends DefaultIndexer
+{
+    public function url(): UriInterface
+    {
+        return $this->url->withQuery('');
+    }
+}

--- a/tests/TestSupport/TestClasses/SearchProfiles/ModifyUrlSearchProfile.php
+++ b/tests/TestSupport/TestClasses/SearchProfiles/ModifyUrlSearchProfile.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\TestSupport\TestClasses\SearchProfiles;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Spatie\SiteSearch\Indexers\Indexer;
+use Spatie\SiteSearch\Profiles\DefaultSearchProfile;
+use Tests\TestSupport\TestClasses\Indexers\IndexerWithModifiedUrl;
+
+class ModifyUrlSearchProfile extends DefaultSearchProfile
+{
+    public function useIndexer(UriInterface $url, ResponseInterface $response): ?Indexer
+    {
+        return new IndexerWithModifiedUrl($url, $response);
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility to modify the URL of a page before it is indexed. This makes it possible to strip away unwanted query parameters for example.

Resolves #21 