### PR TITLE
Make the CrawlSiteJob unique

### DIFF
--- a/src/Jobs/CrawlSiteJob.php
+++ b/src/Jobs/CrawlSiteJob.php
@@ -32,6 +32,11 @@ class CrawlSiteJob implements ShouldQueue, ShouldBeUnique
     ) {
     }
 
+    public function uniqueId(): string
+    {
+        return $this->siteSearchConfig->index_base_name;
+    }
+
     public function handle()
     {
         event(new IndexingStartedEvent($this->siteSearchConfig));

--- a/src/Jobs/CrawlSiteJob.php
+++ b/src/Jobs/CrawlSiteJob.php
@@ -34,7 +34,7 @@ class CrawlSiteJob implements ShouldQueue, ShouldBeUnique
 
     public function uniqueId(): string
     {
-        return $this->siteSearchConfig->index_base_name;
+        return $this->siteSearchConfig->getKey();
     }
 
     public function handle()

--- a/src/Jobs/CrawlSiteJob.php
+++ b/src/Jobs/CrawlSiteJob.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SiteSearch\Jobs;
 
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -14,7 +15,7 @@ use Spatie\SiteSearch\Events\NewIndexCreatedEvent;
 use Spatie\SiteSearch\Models\SiteSearchConfig;
 use Spatie\SiteSearch\SiteSearch;
 
-class CrawlSiteJob implements ShouldQueue
+class CrawlSiteJob implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -23,6 +24,8 @@ class CrawlSiteJob implements ShouldQueue
     protected $numberOfUrlsIndexed = 0;
 
     public $timeout = 60 * 5;
+
+    public $uniqueFor = 60 * 60;
 
     public function __construct(
         public SiteSearchConfig $siteSearchConfig


### PR DESCRIPTION
This prevent the queue from filling up with CrawlSiteJobs when there is one still dispatched