### PR TITLE
Update links to Meilisearch docs

### DIFF
--- a/docs/advanced-usage/customizing-meilisearch-settings.md
+++ b/docs/advanced-usage/customizing-meilisearch-settings.md
@@ -19,11 +19,11 @@ You can customize this by adding a `meilisearch.url` JSON value to the `extra` a
 
 ### Modifying index settings
 
-A Meilisearch index has [various interesting settings](https://docs.meilisearch.com/reference/features/settings.html#settings) that allow you [which fields are searchable](https://docs.meilisearch.com/reference/features/settings.html#searchable-attributes), [specify ranking rules](https://docs.meilisearch.com/reference/features/settings.html#ranking-rules), and even [add synonyms](https://docs.meilisearch.com/reference/features/settings.html#synonyms).
+A Meilisearch index has [various interesting settings](https://www.meilisearch.com/docs/learn/configuration/settings) that allow you [which fields are searchable](https://www.meilisearch.com/docs/reference/api/settings#searchable-attributes), [specify ranking rules](https://www.meilisearch.com/docs/reference/api/settings#ranking-rules), and even [add synonyms](https://www.meilisearch.com/docs/learn/configuration/synonyms).
 
 Every time a site is crawled, a new index is created. You can customize the settings that are used for this index in two ways.
 
-The first way would be by adding a `meilisearch.indexSettings` JSON value to the `extra` attribute in the `site_search_configs`. In `meilisearch.indexSettings` you can put any of [the list settings that Meilisearch provides](https://docs.meilisearch.com/reference/features/settings.html#settings).
+The first way would be by adding a `meilisearch.indexSettings` JSON value to the `extra` attribute in the `site_search_configs`. In `meilisearch.indexSettings` you can put any of [the list settings that Meilisearch provides](https://www.meilisearch.com/docs/learn/configuration/settings).
 
 Here's how that value you would put in `extra` if you only want results based on the `url` and `description` fields in the index.
 
@@ -40,7 +40,7 @@ Here's how that value you would put in `extra` if you only want results based on
 }
 ```
 
-Here's another example where we are going to add a synonym for the word "computer". You can read more about [how synonyms can be configured](https://docs.meilisearch.com/reference/features/synonyms.html) in the Meilisearch docs.
+Here's another example where we are going to add a synonym for the word "computer". You can read more about [how synonyms can be configured](https://www.meilisearch.com/docs/learn/configuration/synonyms) in the Meilisearch docs.
 
 ```json
 {
@@ -61,4 +61,4 @@ The second way to customize index settings would be by leveraging the `Spatie\Si
 - the name of the created Meilisearch object
 - an instance of `Spatie\SiteSearch\Models\SiteSearchConfig`
 
-You can use these properties to make an API call of your own to Meilisearch to customize [any of the available settings](https://docs.meilisearch.com/reference/features/settings.html#settings).
+You can use these properties to make an API call of your own to Meilisearch to customize [any of the available settings](https://www.meilisearch.com/docs/learn/configuration/settings).


### PR DESCRIPTION
Same as before, but in the main branch: Meilisearch docs moved.