### PR TITLE
Use the new reversable prompt form builder and fix CreateSearchConfigCommand Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/psr7": "^2.5",
         "illuminate/contracts": "^10.0|^11.0",
         "illuminate/http": "^10.0|^11.0",
-        "laravel/prompts": "^0.1.1",
+        "laravel/prompts": "^0.1.23",
         "spatie/crawler": "^8.0",
         "spatie/laravel-package-tools": "^1.15"
     },

--- a/src/Commands/CreateSearchConfigCommand.php
+++ b/src/Commands/CreateSearchConfigCommand.php
@@ -5,6 +5,8 @@ namespace Spatie\SiteSearch\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Validator;
 
+use Laravel\Prompts\FormBuilder;
+use function Laravel\Prompts\form;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\text;
@@ -17,26 +19,25 @@ class CreateSearchConfigCommand extends Command
 
     public function handle()
     {
-        intro("Let's create your index!");
+        [, $name, $url] = form()->intro("Let's create your index!")
+            ->text(
+                label: 'What should your index be named?',
+                placeholder: 'E.g. my-index',
+                required: 'An index name is required.'
+            )
+            ->text(
+                label: 'Which url should be crawled to fill this index?',
+                placeholder: 'E.g. https://example.com',
+                required: 'A URL is required.',
+                validate: function (string $value) {
+                    $passes = Validator::make(['url' => $value], [
+                        'url' => 'url',
+                    ])->passes();
 
-        $name = text(
-            label: 'What should your index be named?',
-            placeholder: 'E.g. my-index',
-            required: 'An index name is required.'
-        );
-
-        $url = text(
-            label: 'Which url should be crawled to fill this index?',
-            placeholder: 'E.g. https://example.com',
-            required: 'A URL is required.',
-            validate: function (string $value) {
-                $passes = Validator::make(['url' => $value], [
-                    'url' => 'url',
-                ])->passes();
-
-                return $passes ? null : 'You must enter a valid URL';
-            }
-        );
+                    return $passes ? null : 'You must enter a valid URL';
+                }
+            )
+            ->submit();
 
         SiteSearchConfig::create([
             'name' => $name,

--- a/tests/Commands/CreateSearchConfigCommandTest.php
+++ b/tests/Commands/CreateSearchConfigCommandTest.php
@@ -9,7 +9,7 @@ use Spatie\SiteSearch\Commands\CreateSearchConfigCommand;
 it('has a command to create a site search config', function () {
     artisan(CreateSearchConfigCommand::class)
        ->expectsQuestion('What should your index be named?', 'test-index')
-       ->expectsQuestion('Great! Which url should be crawled to fill this index?', 'https://example.com')
+       ->expectsQuestion('Which url should be crawled to fill this index?', 'https://example.com')
        ->assertExitCode(Command::SUCCESS);
 
     $this->assertDatabaseHas('site_search_configs', [
@@ -18,4 +18,4 @@ it('has a command to create a site search config', function () {
         'index_base_name' => 'test-index',
         'enabled' => 1,
     ]);
-})->todo('Fix this tests when Laravel Prompts are testable');
+});


### PR DESCRIPTION
Hey all!

This PR uses the new Reversible prompt form builder, which allows the user to return to the previous question if they make a mistake.

You can read more about the reversible prompt form builder here: https://github.com/laravel/prompts/pull/118.

##  Wrap-up

Thank you for all the hard work maintaining and working on laravel-site-search; it's very much appreciated.

Regards,
Fermin