### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         stability: [prefer-stable]
+        exclude:
+          - php: 8.2
+            laravel: 13.*
         include:
           - laravel: 10.*
             testbench: 8.*
@@ -26,6 +29,8 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/psr7": "^2.5",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.23|^0.3",
         "spatie/crawler": "^8.0",
         "spatie/laravel-package-tools": "^1.15"
@@ -30,7 +30,7 @@
         "guzzlehttp/guzzle": "^7.7",
         "meilisearch/meilisearch-php": "^1.1.1",
         "nunomaduro/collision": "^7.5.2|^8.0",
-        "orchestra/testbench": "^8.5.5|^9.0|^10.0",
+        "orchestra/testbench": "^8.5.5|^9.0|^10.0|^11.0",
         "pestphp/pest": "^2.6.2|^3.7",
         "pestphp/pest-plugin-laravel": "^2.0|^3.1",
         "spatie/laravel-ray": "^1.32.4"


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/contracts` and `illuminate/http` constraints
- Add `^11.0` to `orchestra/testbench` constraint
- Add Laravel 13 to the CI test matrix (PHP 8.3+ only, as Laravel 13 requires it)