### PR TITLE
Add Laravel 13 support and upgrade to Pest 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,16 +25,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*']
+        php: [8.4, 8.3]
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "guzzlehttp/psr7": "^2.5",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.23|^0.3",
         "spatie/crawler": "^8.0",
         "spatie/laravel-package-tools": "^1.15"
@@ -29,10 +29,10 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^7.7",
         "meilisearch/meilisearch-php": "^1.1.1",
-        "nunomaduro/collision": "^7.5.2|^8.0",
-        "orchestra/testbench": "^8.5.5|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.6.2|^3.7",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.1",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.7|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.1|^4.0",
         "spatie/laravel-ray": "^1.32.4"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Spatie Test Suite">
       <directory>tests</directory>
       <exclude>./tests/TestSupport/Server</exclude>
     </testsuite>
   </testsuites>
-  <coverage>
-    <report>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
   <source>
     <include>
       <directory suffix=".php">./src</directory>


### PR DESCRIPTION
## Summary
- Add Laravel 13 support with `^13.0` illuminate constraints and testbench `^11.0`
- Upgrade to Pest 4 (`^4.0`) and pest-plugin-laravel `^4.0`
- Drop Laravel 10 and PHP 8.2 (required by Pest 4)
- Bump minimum PHP to `^8.3`