### PR TITLE
Strip MySQL fulltext boolean mode operators from search terms

### DIFF
--- a/config/site-search.php
+++ b/config/site-search.php
@@ -1,5 +1,10 @@
 <?php
 
+use Spatie\SiteSearch\Drivers\DatabaseDriver;
+use Spatie\SiteSearch\Indexers\DefaultIndexer;
+use Spatie\SiteSearch\Jobs\CrawlSiteJob;
+use Spatie\SiteSearch\Profiles\DefaultSearchProfile;
+
 return [
     /*
      * When crawling your site, we will ignore content that is on these URLs.
@@ -49,7 +54,7 @@ return [
      * This profile will be used when none is specified in the `profile_class` attribute
      * of a `SiteSearchIndex` model.
      */
-    'default_profile' => Spatie\SiteSearch\Profiles\DefaultSearchProfile::class,
+    'default_profile' => DefaultSearchProfile::class,
 
     /*
      * An indexer is a class that is responsible for converting the content of a page
@@ -58,7 +63,7 @@ return [
      * This indexer will be used when none is specified in the `profile_class` attribute
      * of a `SiteSearchIndex` model.
      */
-    'default_indexer' => Spatie\SiteSearch\Indexers\DefaultIndexer::class,
+    'default_indexer' => DefaultIndexer::class,
 
     /*
      * A driver is responsible for writing all scraped content
@@ -69,12 +74,12 @@ return [
      * - MeiliSearchDriver: uses Meilisearch as the search engine (requires a running Meilisearch instance)
      * - ArrayDriver: in-memory driver for testing
      */
-    'default_driver' => Spatie\SiteSearch\Drivers\DatabaseDriver::class,
+    'default_driver' => DatabaseDriver::class,
 
     /*
      * This job is responsible for crawling your site. To customize this job,
      * you can extend the default one, and specify the class name of
      * your customized job here.
      */
-    'crawl_site_job' => Spatie\SiteSearch\Jobs\CrawlSiteJob::class,
+    'crawl_site_job' => CrawlSiteJob::class,
 ];

--- a/src/Drivers/Database/Grammar.php
+++ b/src/Drivers/Database/Grammar.php
@@ -14,11 +14,9 @@ abstract class Grammar
 
     public function escapeSearchTerm(string $query): string
     {
-        $escaped = str_replace(
-            ['"', '*', '(', ')', ':'],
-            ['', '', '', '', ''],
-            $query
-        );
+        $booleanModeOperators = ['"', '*', '(', ')', ':', '@', '+', '-', '~', '<', '>'];
+
+        $escaped = str_replace($booleanModeOperators, ' ', $query);
 
         $escaped = preg_replace('/\b(OR|AND|NOT)\b/i', '', $escaped);
 

--- a/src/Models/SiteSearchConfig.php
+++ b/src/Models/SiteSearchConfig.php
@@ -63,7 +63,7 @@ class SiteSearchConfig extends Model
 
     public function getDriver(): Driver
     {
-        /** @var \Spatie\SiteSearch\Drivers\Driver $driverClass */
+        /** @var Driver $driverClass */
         $driverClass = $this->driver_class ?? config('site-search.default_driver');
 
         return $driverClass::make($this);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ if (! function_exists('attempt')) {
     {
         try {
             return $closure();
-        } catch (\Exception) {
+        } catch (Exception) {
             return $default;
         }
     }

--- a/tests/Commands/ListCommandTest.php
+++ b/tests/Commands/ListCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\SiteSearch\Models\SiteSearchConfig;
 use Symfony\Component\Console\Command\ListCommand;
 
@@ -19,8 +20,8 @@ it('displays crawl progress columns', function () {
         'finish_reason' => 'completed',
     ]);
 
-    \Illuminate\Support\Facades\Artisan::call('site-search:list');
-    $output = \Illuminate\Support\Facades\Artisan::output();
+    Artisan::call('site-search:list');
+    $output = Artisan::output();
 
     expect($output)
         ->toContain('URLs Found')

--- a/tests/Drivers/Database/GrammarTest.php
+++ b/tests/Drivers/Database/GrammarTest.php
@@ -7,9 +7,27 @@ use Spatie\SiteSearch\Drivers\Database\SqliteGrammar;
 
 it('escapes dangerous characters from search terms', function (Grammar $grammar) {
     expect($grammar->escapeSearchTerm('"hello"'))->toBe('hello');
-    expect($grammar->escapeSearchTerm('hello*world'))->toBe('helloworld');
-    expect($grammar->escapeSearchTerm('test(group)'))->toBe('testgroup');
-    expect($grammar->escapeSearchTerm('field:value'))->toBe('fieldvalue');
+    expect($grammar->escapeSearchTerm('hello*world'))->toBe('hello world');
+    expect($grammar->escapeSearchTerm('test(group)'))->toBe('test group');
+    expect($grammar->escapeSearchTerm('field:value'))->toBe('field value');
+})->with([
+    'sqlite' => fn () => new SqliteGrammar,
+    'mysql' => fn () => new MySqlGrammar,
+    'postgres' => fn () => new PostgresGrammar,
+]);
+
+it('strips mysql boolean mode operators that would break the query', function (Grammar $grammar) {
+    expect($grammar->escapeSearchTerm('icu4c@78'))->toBe('icu4c 78');
+    expect($grammar->escapeSearchTerm('rank>up'))->toBe('rank up');
+    expect($grammar->escapeSearchTerm('rank<down'))->toBe('rank down');
+    expect($grammar->escapeSearchTerm('~negate'))->toBe('negate');
+
+    // The real-world path that triggered the crash on freek.dev should no longer
+    // contain any boolean mode operator that breaks MySQL's fulltext parser.
+    $path = '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/icu4c@78/lib/libicuio.78.dylib';
+    expect($grammar->escapeSearchTerm($path))
+        ->not->toContain('@')
+        ->not->toContain('-');
 })->with([
     'sqlite' => fn () => new SqliteGrammar,
     'mysql' => fn () => new MySqlGrammar,

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -4,11 +4,14 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Event;
 use Spatie\Crawler\CrawlProgress;
 use Spatie\Crawler\Enums\FinishReason;
+use Spatie\SiteSearch\Drivers\DatabaseDriver;
+use Spatie\SiteSearch\Drivers\MeiliSearchDriver;
 use Spatie\SiteSearch\Events\CrawlFinishedEvent;
 use Spatie\SiteSearch\Events\IndexedUrlEvent;
 use Spatie\SiteSearch\Jobs\CrawlSiteJob;
 use Spatie\SiteSearch\Models\SiteSearchConfig;
 use Spatie\SiteSearch\Search;
+use Spatie\SiteSearch\SearchResults\Hit;
 use Tests\TestSupport\Server\Server;
 use Tests\TestSupport\TestClasses\SearchProfiles\DoNotCrawlSecondLinkSearchProfile;
 use Tests\TestSupport\TestClasses\SearchProfiles\DoNotIndexSecondLinkSearchProfile;
@@ -17,10 +20,10 @@ use Tests\TestSupport\TestClasses\SearchProfiles\SearchProfileWithCustomIndexer;
 
 dataset('drivers', [
     'database' => [fn () => [
-        'driver_class' => \Spatie\SiteSearch\Drivers\DatabaseDriver::class,
+        'driver_class' => DatabaseDriver::class,
     ]],
     'meilisearch' => [fn () => [
-        'driver_class' => \Spatie\SiteSearch\Drivers\MeiliSearchDriver::class,
+        'driver_class' => MeiliSearchDriver::class,
     ]],
 ]);
 
@@ -28,7 +31,7 @@ beforeEach(function () {
     Server::boot();
 
     $this->siteSearchConfig = SiteSearchConfig::factory()->create([
-        'driver_class' => \Spatie\SiteSearch\Drivers\DatabaseDriver::class,
+        'driver_class' => DatabaseDriver::class,
     ]);
 });
 
@@ -47,7 +50,7 @@ it('can crawl a site', function (Closure $driverSetup) {
 
     expect($searchResults->hits)->toHaveCount(1);
 
-    /** @var \Spatie\SiteSearch\SearchResults\Hit $hit */
+    /** @var Hit $hit */
     $hit = $searchResults->hits[0];
 
     expect($hit)
@@ -304,7 +307,7 @@ it('can add extra properties', function (Closure $driverSetup) {
 it('synonyms can be specified by customizing the index settings', function () {
     $this->siteSearchConfig->update([
         'profile_class' => SearchProfileWithCustomIndexer::class,
-        'driver_class' => \Spatie\SiteSearch\Drivers\MeiliSearchDriver::class,
+        'driver_class' => MeiliSearchDriver::class,
     ]);
 
     $extraValue = [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Pagination\Paginator;
+use MeiliSearch\Client;
+use MeiliSearch\Contracts\TasksQuery;
+use Spatie\SiteSearch\Drivers\MeiliSearchDriver;
 use Spatie\SiteSearch\Models\SiteSearchConfig;
 use Spatie\SiteSearch\SearchResults\Hit;
 use Spatie\SiteSearch\SearchResults\SearchResults;
@@ -14,15 +17,15 @@ function waitForDriver(SiteSearchConfig $siteSearchConfig): void
 {
     $driverClass = $siteSearchConfig->driver_class ?? config('site-search.default_driver');
 
-    if ($driverClass !== \Spatie\SiteSearch\Drivers\MeiliSearchDriver::class) {
+    if ($driverClass !== MeiliSearchDriver::class) {
         return;
     }
 
     $indexName = $siteSearchConfig->refresh()->index_name;
 
-    $client = new MeiliSearch\Client('http://127.0.0.1:7700');
+    $client = new Client('http://127.0.0.1:7700');
 
-    $tasks = $client->getTasks(new MeiliSearch\Contracts\TasksQuery([
+    $tasks = $client->getTasks(new TasksQuery([
         'indexUids' => [$indexName],
         'statuses' => ['enqueued', 'processing'],
     ]));


### PR DESCRIPTION
## Problem

Search terms flow into a MySQL `MATCH(...) AGAINST(? IN BOOLEAN MODE)` query. In boolean mode, MySQL has its own mini-syntax with the operators `+ - > < ( ) ~ * " @`. When user input contains one of these, MySQL's fulltext parser raises a 1064 syntax error instead of treating the input as data.

A real-world example: a visitor searched for the path `/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/icu4c@78/lib/libicuio.78.dylib`. The `@` is MySQL 8's proximity operator, so `icu4c@78` is invalid boolean-mode syntax and the query blew up with:

```
SQLSTATE[42000]: Syntax error or access violation: 1064 ... unexpected '@', expecting $end
```

`escapeSearchTerm()` only stripped `" * ( ) :`, leaving `@ + - ~ < >` untouched.

## Fix

Add the remaining boolean-mode operators to the escaped set, and replace stripped operators with a space rather than removing them. Every driver already splits the escaped term on whitespace before building its query, so a path like `icu4c@78` becomes two searchable tokens (`icu4c`, `78`) instead of a single mangled one.

## Tests

Added a regression test (run against all three database grammars) covering the operators that previously broke the parser, including the exact path that caused the production failure. Updated the existing dangerous-characters test to reflect space-separation.